### PR TITLE
Unify Handlers via Adapter Interfaces (Future-Proof)

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/Spawning/INetworkPrefabInstanceHandlerAdapter.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Spawning/INetworkPrefabInstanceHandlerAdapter.cs
@@ -1,0 +1,24 @@
+using UnityEngine;
+
+namespace Unity.Netcode
+{
+
+    //This interface is used to allow the PrefabHandler to use the INetworkPrefabInstanceHandlerSource, so in this way we avoid having to add a different implementation
+    // of AddHandler for each of the posible INetworkPrefabInstanceHandlerSource implementations
+    internal interface INetworkPrefabInstanceHandlerAdapter
+    {
+        NetworkObject Instantiate(ulong ownerClientId, Vector3 position, Quaternion rotation, FastBufferReader instantiationDataReader = default);
+        bool HandlesDataOfType<T>();
+        void Destroy(NetworkObject networkObject);
+    }
+
+    public interface INetworkPrefabInstanceHandlerSource
+    {
+        //This interface requiring an implementation of CreateHandlerAdapter is also a way to disallow users to use INetworkPrefabInstanceHandlerSource
+        // Outside the assembly, as it is internal and will give compilation errors.
+        // BUT!!
+        // I think we can make this also public, in that way users could create their own wrappers giving even more flexibility
+        // By default, the current internal interfaces uses a default implementation of CreateHandlerAdapterm so users dont need to add this
+        internal INetworkPrefabInstanceHandlerAdapter CreateHandlerAdapter();
+    }
+}

--- a/com.unity.netcode.gameobjects/Runtime/Spawning/INetworkPrefabInstanceHandlerAdapter.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Spawning/INetworkPrefabInstanceHandlerAdapter.cs
@@ -5,6 +5,7 @@ namespace Unity.Netcode
 
     //This interface is used to allow the PrefabHandler to use the INetworkPrefabInstanceHandlerSource, so in this way we avoid having to add a different implementation
     // of AddHandler for each of the posible INetworkPrefabInstanceHandlerSource implementations
+    // POSIBLY MAKE THIS PUBLIC, SO USERS CAN CREATE THEIR OWN ADAPTERS, READ THE NOTE IN THE OTHER INTERFACE
     internal interface INetworkPrefabInstanceHandlerAdapter
     {
         NetworkObject Instantiate(ulong ownerClientId, Vector3 position, Quaternion rotation, FastBufferReader instantiationDataReader = default);
@@ -17,7 +18,7 @@ namespace Unity.Netcode
         //This interface requiring an implementation of CreateHandlerAdapter is also a way to disallow users to use INetworkPrefabInstanceHandlerSource
         // Outside the assembly, as it is internal and will give compilation errors.
         // BUT!!
-        // I think we can make this also public, in that way users could create their own wrappers giving even more flexibility
+        // I think we can make this also public along with the Adapter Interface, in that way users could create their own wrappers giving even more flexibility
         // By default, the current internal interfaces uses a default implementation of CreateHandlerAdapterm so users dont need to add this
         internal INetworkPrefabInstanceHandlerAdapter CreateHandlerAdapter();
     }

--- a/com.unity.netcode.gameobjects/Runtime/Spawning/INetworkPrefabInstanceHandlerAdapter.cs.meta
+++ b/com.unity.netcode.gameobjects/Runtime/Spawning/INetworkPrefabInstanceHandlerAdapter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a67c8648dff0ac14aaef74e8cf6db654

--- a/com.unity.netcode.gameobjects/Runtime/Spawning/INetworkPrefabInstanceHandlerWithData.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Spawning/INetworkPrefabInstanceHandlerWithData.cs
@@ -9,33 +9,32 @@ namespace Unity.Netcode
     /// Specialized version of <see cref="INetworkPrefabInstanceHandler"/> that receives
     /// custom instantiation data injected by the server before spawning.
     /// </summary>
-    public interface INetworkPrefabInstanceHandlerWithData<T> where T : struct, INetworkSerializable
+    public interface INetworkPrefabInstanceHandlerWithData<T> : INetworkPrefabInstanceHandlerSource where T : struct, INetworkSerializable
     {
         NetworkObject Instantiate(ulong ownerClientId, Vector3 position, Quaternion rotation, T instantiationData);
         void Destroy(NetworkObject networkObject);
+        INetworkPrefabInstanceHandlerAdapter INetworkPrefabInstanceHandlerSource.CreateHandlerAdapter()
+        {
+            return new PrefabInstanceHandlerWithDataAdapter<T>(this);
+        }
     }
 
-    internal interface INetworkPrefabInstanceHandlerWithData : INetworkPrefabInstanceHandler
-    {
-        NetworkObject Instantiate(ulong ownerClientId, Vector3 position, Quaternion rotation, FastBufferReader reader);
-        bool HandlesDataType<T>();
-    }
-
-    internal class HandlerWrapper<T> : INetworkPrefabInstanceHandlerWithData where T : struct, INetworkSerializable
+    internal class PrefabInstanceHandlerWithDataAdapter<T> : INetworkPrefabInstanceHandlerAdapter where T : struct, INetworkSerializable
     {
         private readonly INetworkPrefabInstanceHandlerWithData<T> _impl;
         
-        public HandlerWrapper(INetworkPrefabInstanceHandlerWithData<T> impl) => _impl = impl;
+        public PrefabInstanceHandlerWithDataAdapter(INetworkPrefabInstanceHandlerWithData<T> impl) => _impl = impl;
 
-        public bool HandlesDataType<U>() => typeof(T) == typeof(U);
+        public bool HandlesDataOfType<U>() => typeof(T) == typeof(U);
 
-        public NetworkObject Instantiate(ulong ownerClientId, Vector3 position, Quaternion rotation, FastBufferReader reader)
+        public NetworkObject Instantiate(ulong ownerClientId, Vector3 position, Quaternion rotation, FastBufferReader reader = default)
         {
+            if(!reader.IsInitialized)
+                return _impl.Instantiate(ownerClientId, position, rotation, default);
+
             reader.ReadValueSafe(out T _payload);
             return _impl.Instantiate(ownerClientId, position, rotation, _payload);
         }
-
-        public NetworkObject Instantiate(ulong ownerClientId, Vector3 position, Quaternion rotation) => _impl.Instantiate(ownerClientId, position, rotation, default);
         public void Destroy(NetworkObject networkObject) => _impl.Destroy(networkObject);
     }
 }

--- a/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkPrefabHandler.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkPrefabHandler.cs
@@ -126,7 +126,7 @@ namespace Unity.Netcode
         }
         public void SetInstantiationData<T>(NetworkObject networkObject, T data) where T : struct, INetworkSerializable
         {
-            if (!TryGetInstantiator(networkObject.GlobalObjectIdHash, out var prefabHandler) || !prefabHandler.HandlesDataOfType<T>())
+            if (!TryGetHandlerAdapter(networkObject.GlobalObjectIdHash, out var prefabHandler) || !prefabHandler.HandlesDataOfType<T>())
             {
                 throw new Exception("[InstantiationData] Cannot inject data: no compatible handler found for the specified data type.");
             }
@@ -270,7 +270,7 @@ namespace Unity.Netcode
         /// <param name="objectHash"></param>
         /// <param name="handler"></param>
         /// <returns></returns>
-        internal bool TryGetInstantiator(uint objectHash, out INetworkPrefabInstanceHandlerAdapter handler)
+        internal bool TryGetHandlerAdapter(uint objectHash, out INetworkPrefabInstanceHandlerAdapter handler)
         {
             return m_PrefabAssetToPrefabHandler.TryGetValue(objectHash, out handler);
         }
@@ -283,7 +283,7 @@ namespace Unity.Netcode
         /// <param name="serializer"></param>
         internal FastBufferReader GetInstantiationDataReader<T>(uint objectHash, ref BufferSerializer<T> serializer) where T : IReaderWriter
         {
-            if (!serializer.IsReader || !TryGetInstantiator(objectHash, out INetworkPrefabInstanceHandlerAdapter synchronizableHandler))
+            if (!serializer.IsReader || !TryGetHandlerAdapter(objectHash, out INetworkPrefabInstanceHandlerAdapter synchronizableHandler))
             {
                 return default;
             }

--- a/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkPrefabHandler.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkPrefabHandler.cs
@@ -8,7 +8,7 @@ namespace Unity.Netcode
     /// Interface for customizing, overriding, spawning, and destroying Network Prefabs
     /// Used by <see cref="NetworkPrefabHandler"/>
     /// </summary>
-    public interface INetworkPrefabInstanceHandler
+    public interface INetworkPrefabInstanceHandler : INetworkPrefabInstanceHandlerSource
     {
         /// <summary>
         /// Client Side Only
@@ -45,6 +45,18 @@ namespace Unity.Netcode
         /// </summary>
         /// <param name="networkObject">The <see cref="NetworkObject"/> being destroyed</param>
         void Destroy(NetworkObject networkObject);
+
+        INetworkPrefabInstanceHandlerAdapter INetworkPrefabInstanceHandlerSource.CreateHandlerAdapter() => new LegacyHandlerAdapter(this);
+    }
+
+
+    internal class LegacyHandlerAdapter : INetworkPrefabInstanceHandlerAdapter
+    {
+        private readonly INetworkPrefabInstanceHandler handler;
+        public LegacyHandlerAdapter(INetworkPrefabInstanceHandler handler) => this.handler = handler;
+        public bool HandlesDataOfType<T>() => false;
+        public NetworkObject Instantiate(ulong ownerClientId, Vector3 position, Quaternion rotation, FastBufferReader instantiationDataReader = default) => handler.Instantiate(ownerClientId, position, rotation);
+        public void Destroy(NetworkObject networkObject) => handler.Destroy(networkObject);
     }
 
     /// <summary>
@@ -58,13 +70,7 @@ namespace Unity.Netcode
         /// <summary>
         /// Links a network prefab asset to a class with the INetworkPrefabInstanceHandler interface
         /// </summary>
-        private readonly Dictionary<uint, INetworkPrefabInstanceHandler> m_PrefabAssetToPrefabHandler = new Dictionary<uint, INetworkPrefabInstanceHandler>();
-
-        /// <summary>
-        /// Links a network prefab asset to a class with the INetworkPrefabInstanceHandlerWithData interface,
-        /// used to keep a smaller lookup table than <see cref="m_PrefabAssetToPrefabHandler"/> for faster instantiation data injection into NetworkObject
-        /// </summary>
-        private readonly Dictionary<uint, INetworkPrefabInstanceHandlerWithData> m_PrefabAssetToPrefabHandlerWithData = new Dictionary<uint, INetworkPrefabInstanceHandlerWithData>();
+        private readonly Dictionary<uint, INetworkPrefabInstanceHandlerAdapter> m_PrefabAssetToPrefabHandler = new Dictionary<uint, INetworkPrefabInstanceHandlerAdapter>();
 
         /// <summary>
         /// Links the custom prefab instance's GlobalNetworkObjectId to the original prefab asset's GlobalNetworkObjectId.  (Needed for HandleNetworkPrefabDestroy)
@@ -80,11 +86,7 @@ namespace Unity.Netcode
         /// <param name="networkPrefabAsset">the <see cref="GameObject"/> of the network prefab asset to be overridden</param>
         /// <param name="instanceHandler">class that implements the <see cref="INetworkPrefabInstanceHandler"/> interface to be registered</param>
         /// <returns>true (registered) false (failed to register)</returns>
-        public bool AddHandler(GameObject networkPrefabAsset, INetworkPrefabInstanceHandler instanceHandler)
-        {
-            return AddHandler(networkPrefabAsset.GetComponent<NetworkObject>().GlobalObjectIdHash, instanceHandler);
-        }
-        public bool AddHandler<T>(GameObject networkPrefabAsset, INetworkPrefabInstanceHandlerWithData<T> instanceHandler) where T : struct, INetworkSerializable
+        public bool AddHandler(GameObject networkPrefabAsset, INetworkPrefabInstanceHandlerSource instanceHandler)
         {
             return AddHandler(networkPrefabAsset.GetComponent<NetworkObject>().GlobalObjectIdHash, instanceHandler);
         }
@@ -95,14 +97,11 @@ namespace Unity.Netcode
         /// <param name="prefabAssetNetworkObject"> the <see cref="NetworkObject"/> of the network prefab asset to be overridden</param>
         /// <param name="instanceHandler">the class that implements the <see cref="INetworkPrefabInstanceHandler"/> interface to be registered</param>
         /// <returns>true (registered) false (failed to register)</returns>
-        public bool AddHandler(NetworkObject prefabAssetNetworkObject, INetworkPrefabInstanceHandler instanceHandler)
+        public bool AddHandler(NetworkObject prefabAssetNetworkObject, INetworkPrefabInstanceHandlerSource instanceHandler)
         {
             return AddHandler(prefabAssetNetworkObject.GlobalObjectIdHash, instanceHandler);
         }
-        public bool AddHandler<T>(NetworkObject prefabAssetNetworkObject, INetworkPrefabInstanceHandlerWithData<T> instanceHandler) where T : struct, INetworkSerializable
-        {
-            return AddHandler(prefabAssetNetworkObject.GlobalObjectIdHash, instanceHandler);
-        }
+
 
         /// <summary>
         /// Use a <see cref="NetworkObject.GlobalObjectIdHash"/> to register a class that implements the <see cref="INetworkPrefabInstanceHandler"/> interface with the <see cref="NetworkPrefabHandler"/>
@@ -110,24 +109,13 @@ namespace Unity.Netcode
         /// <param name="globalObjectIdHash"> the <see cref="NetworkObject.GlobalObjectIdHash"/> value of the network prefab asset being overridden</param>
         /// <param name="instanceHandler">a class that implements the <see cref="INetworkPrefabInstanceHandler"/> interface</param>
         /// <returns>true (registered) false (failed to register)</returns>
-        public bool AddHandler(uint globalObjectIdHash, INetworkPrefabInstanceHandler instanceHandler)
+        public bool AddHandler(uint globalObjectIdHash, INetworkPrefabInstanceHandlerSource instanceHandler)
         {
             if (!m_PrefabAssetToPrefabHandler.ContainsKey(globalObjectIdHash))
             {
-                m_PrefabAssetToPrefabHandler.Add(globalObjectIdHash, instanceHandler);
-                if (instanceHandler is INetworkPrefabInstanceHandlerWithData instanceHandlerWithData)
-                {
-                    m_PrefabAssetToPrefabHandlerWithData.Add(globalObjectIdHash, instanceHandlerWithData);
-                }
+                m_PrefabAssetToPrefabHandler.Add(globalObjectIdHash, instanceHandler.CreateHandlerAdapter());
                 return true;
             }
-
-            return false;
-        }
-        public bool AddHandler<T>(uint globalObjectIdHash, INetworkPrefabInstanceHandlerWithData<T> instanceHandler) where T : struct, INetworkSerializable
-        {
-            if (!m_PrefabAssetToPrefabHandler.ContainsKey(globalObjectIdHash))
-                return AddHandler(globalObjectIdHash, new HandlerWrapper<T>(instanceHandler));
             return false;
         }
 
@@ -138,7 +126,7 @@ namespace Unity.Netcode
         }
         public void InjectInstantiationData<T>(NetworkObject networkObject, T data) where T : struct, INetworkSerializable
         {
-            if (!TryGetHandlerWithData(networkObject.GlobalObjectIdHash, out var prefabHandler) || !prefabHandler.HandlesDataType<T>())
+            if (!TryGetInstantiator(networkObject.GlobalObjectIdHash, out var prefabHandler) || !prefabHandler.HandlesDataOfType<T>())
             {
                 throw new Exception("[InstantiationData] Cannot inject data: no compatible handler found for the specified data type.");
             }
@@ -252,10 +240,6 @@ namespace Unity.Netcode
                 m_PrefabInstanceToPrefabAsset.Remove(networkPrefabHashKey);
             }
 
-            if(m_PrefabAssetToPrefabHandlerWithData.TryGetValue(globalObjectIdHash, out var handlerWithData))
-            {
-                m_PrefabAssetToPrefabHandlerWithData.Remove(globalObjectIdHash);
-            }
             return m_PrefabAssetToPrefabHandler.Remove(globalObjectIdHash);
         }
 
@@ -286,9 +270,9 @@ namespace Unity.Netcode
         /// <param name="objectHash"></param>
         /// <param name="handler"></param>
         /// <returns></returns>
-        internal bool TryGetHandlerWithData(uint objectHash, out INetworkPrefabInstanceHandlerWithData handler)
+        internal bool TryGetInstantiator(uint objectHash, out INetworkPrefabInstanceHandlerAdapter handler)
         {
-            return m_PrefabAssetToPrefabHandlerWithData.TryGetValue(objectHash, out handler);
+            return m_PrefabAssetToPrefabHandler.TryGetValue(objectHash, out handler);
         }
 
         /// <summary>
@@ -299,7 +283,7 @@ namespace Unity.Netcode
         /// <param name="serializer"></param>
         internal FastBufferReader GetInstantiationDataReader<T>(uint objectHash, ref BufferSerializer<T> serializer) where T : IReaderWriter
         {
-            if (!serializer.IsReader || !TryGetHandlerWithData(objectHash, out INetworkPrefabInstanceHandlerWithData synchronizableHandler))
+            if (!serializer.IsReader || !TryGetInstantiator(objectHash, out INetworkPrefabInstanceHandlerAdapter synchronizableHandler))
             {
                 return default;
             }
@@ -344,36 +328,18 @@ namespace Unity.Netcode
         /// <returns></returns>
         internal NetworkObject HandleNetworkPrefabSpawn(uint networkPrefabAssetHash, ulong ownerClientId, Vector3 position, Quaternion rotation, FastBufferReader instantiationDataReader = default)
         {
-            NetworkObject networkObjectInstance = instantiationDataReader.IsInitialized
-                ? InstantiateNetworkPrefabWithData(networkPrefabAssetHash, ownerClientId, position, rotation, instantiationDataReader)
-                : InstantiateNetworkPrefabDefault(networkPrefabAssetHash, ownerClientId, position, rotation);
-            //Now we must make sure this alternate PrefabAsset spawned in place of the prefab asset with the networkPrefabAssetHash (GlobalObjectIdHash)
-            //is registered and linked to the networkPrefabAssetHash so during the HandleNetworkPrefabDestroy process we can identify the alternate prefab asset.
-            if (networkObjectInstance != null)
-                RegisterPrefabInstance(networkObjectInstance, networkPrefabAssetHash);
-            return networkObjectInstance;
-        }
-
-        private NetworkObject InstantiateNetworkPrefabDefault(uint networkPrefabAssetHash, ulong ownerClientId, Vector3 position, Quaternion rotation)
-        {
             if (m_PrefabAssetToPrefabHandler.TryGetValue(networkPrefabAssetHash, out var prefabInstanceHandler))
-                return prefabInstanceHandler.Instantiate(ownerClientId, position, rotation);
-            return null;
-        }
-
-        private NetworkObject InstantiateNetworkPrefabWithData(uint networkPrefabAssetHash, ulong ownerClientId, Vector3 position, Quaternion rotation, FastBufferReader instantiationDataReader)
-        {
-            if (m_PrefabAssetToPrefabHandlerWithData.TryGetValue(networkPrefabAssetHash, out var prefabInstanceHandler))
-                return prefabInstanceHandler.Instantiate(ownerClientId, position, rotation, instantiationDataReader);
-            return null;
-        }
-
-        private void RegisterPrefabInstance(NetworkObject networkObjectInstance, uint networkPrefabAssetHash)
-        {
-            if (networkObjectInstance != null && !m_PrefabInstanceToPrefabAsset.ContainsKey(networkObjectInstance.GlobalObjectIdHash))
             {
-                m_PrefabInstanceToPrefabAsset.Add(networkObjectInstance.GlobalObjectIdHash, networkPrefabAssetHash);
+                var networkObjectInstance = prefabInstanceHandler.Instantiate(ownerClientId, position, rotation, instantiationDataReader);
+                //Now we must make sure this alternate PrefabAsset spawned in place of the prefab asset with the networkPrefabAssetHash (GlobalObjectIdHash)
+                //is registered and linked to the networkPrefabAssetHash so during the HandleNetworkPrefabDestroy process we can identify the alternate prefab asset.
+                if (networkObjectInstance != null && !m_PrefabInstanceToPrefabAsset.ContainsKey(networkObjectInstance.GlobalObjectIdHash))
+                {
+                    m_PrefabInstanceToPrefabAsset.Add(networkObjectInstance.GlobalObjectIdHash, networkPrefabAssetHash);
+                }
+                return networkObjectInstance;
             }
+            return null;
         }
 
         /// <summary>


### PR DESCRIPTION
_Please drop all related feedback into the source PR for having everything in the same place_

## Key improvements in this extended branch of PR https://github.com/Unity-Technologies/com.unity.netcode.gameobjects/pull/3430/

- **New interfaces**
  - public `INetworkPrefabInstanceHandlerSource`: Common abstraction for all handler types, exposing a consistent adapter regardless of instantiation data
  - internal `INetworkPrefabInstanceHandlerAdapter`: Centralizes the instantiation flow under a single contract, removing the need for branching based on handler type
>**While `INetworkPrefabInstanceHandlerAdapter` remains internal, its design allows safe exposure for custom user-defined adapters if needed** 

- **Adapter-based routing**
  - All handler types (`INetworkPrefabInstanceHandler`, `INetworkPrefabInstanceHandlerWithData<T>`, `future variants...`) now expose an adapter via `INetworkPrefabInstanceHandlerSource`
  - Eliminates type checks and separate dictionaries by handler type
  - Unifies all instantiation logic: for example, `AddHandler` now operate via the unified interfaces
  - The adapter determines whether custom data is needed, removing branching and parallel data paths
  - The system operates entirely through the adapter interface, **reducing complexity and maintenance overhead**

- **Compatibility adapters**
`LegacyHandlerAdapter` and `PrefabInstanceHandlerWithDataAdapter` wrap existing implementations without changing their internal behavior, **for backwards compatibility**